### PR TITLE
Use Octave instead of Matlab

### DIFF
--- a/01sampling/00sample.py
+++ b/01sampling/00sample.py
@@ -11,10 +11,10 @@ samples = 5000
 
 def generateSamples(datafile, stepSize=1500, samples=5000):
     accepted = []
-    print 'Read data for sampling'
+    print('Read data for sampling')
     data = joblib.load(datafile)
 
-    accepted = sorted(data[data.keys()[0]].keys())
+    accepted = sorted(data[list(data.keys())[0]].keys())
     chunks = []
     start = 0
     chunk = []
@@ -45,7 +45,7 @@ def generateSamples(datafile, stepSize=1500, samples=5000):
         os.makedirs('sampled/sampling{0:04d}'.format(i))
 
         f = open('sampled/sampling{0:04d}/input.seq'.format(i), 'w')
-        print i, len(accepted2)
+        print(i, len(accepted2))
         for sequence in data.keys():
             S = data[sequence]
             f.write('>{:s}\n'.format(sequence))

--- a/02inference/00rungenomeDCA.py
+++ b/02inference/00rungenomeDCA.py
@@ -46,6 +46,6 @@ try:
 
             t = subprocess.check_output([matlab, '-nodesktop', '-r', "path(path, 'PLMDCAPATH'); path(path, 'PLMDCAPATH/functions'); path(path, 'PLMDCAPATH/3rd_party_code/minFunc/'); plmDCA_asymmetric ( '".replace('PLMDCAPATH', plmdca) + infilestem + ".seq', '" + infilestem + ".genomedca', 0.1, {:d}); exit".format(cores)])
 except Exception as e:
-    print e
+    print(e)
     sys.stderr.write('{:s} inputfile1.seq [inputfile2.seq ...]\n'.format(sys.argv[0])) 
     sys.stderr.write('\nThis script will run genomeDCA on all the input files provided in the command line\nREMEMBER: set the path to MATLAB executable and genomeDCA code in the header of the script\n')

--- a/02inference/00rungenomeDCAoctave.py
+++ b/02inference/00rungenomeDCAoctave.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+import sys, subprocess, os
+import string as s
+
+# Change 4 to the desired number of cores genomeDCA is to use.
+cores = 1
+
+### Change this to reflect the path to your MATLAB executable
+matlab = 'octave'
+####
+
+### Change this to reflect the path to the genomeDCA code
+plmdca = '/home/guest/software/genomeDCA'
+####
+
+try:
+    if len(sys.argv) < 2:
+        raise
+    try:
+        if not os.path.exists(matlab):
+            sys.stderr.write('MATLAB executable path is not set properly. Trying to find it in system path\n')
+            matlab = subprocess.check_output(['which', 'matlab']).strip()
+    except:
+        sys.stderr.write('Cannot find MATLAB executable, the path in {:s} is set erroneusly and the executable cannot be found automatically.\n'.format(sys.argv[0]))
+        sys.exit(0)
+        
+    if not os.path.exists(plmdca + '/plmDCA_asymmetric.m'):
+        sys.stderr.write('genomeDCA path is not set properly. Trying to find it in {:s}\n'.format(os.path.dirname(os.path.realpath(sys.argv[0]))))
+        plmdca = os.path.dirname(os.path.realpath(sys.argv[0])) + '/genomeDCA'
+
+    if not os.path.exists(plmdca + '/plmDCA_asymmetric.m'):
+        sys.stderr.write('Still not found!\n')
+        sys.exit(0)
+    else:
+        sys.stderr.write('Found!\n (NB: Please do set the path properly...)\n')
+
+    for infile in sys.argv[1:]:
+        os.chdir(os.path.abspath(infile)[:os.path.abspath(infile).rfind('/')]) 
+        infilestem = infile.split('/')[-1]
+        infilestem = infilestem[:infilestem.rfind('.')]
+
+        if not os.path.exists(infilestem + ".genomedca"):
+            print("Running genomeDCA on {:s}'".format(infile))
+            print(' '.join([matlab, '--no-gui', '--eval', "pkg load bioinfo; path(path, 'PLMDCAPATH'); path(path, 'PLMDCAPATH/functions'); path(path, 'PLMDCAPATH/3rd_party_code/minFunc/'); plmDCA_asymmetric ( '".replace('PLMDCAPATH', plmdca) + infilestem + ".seq', '" + infilestem + ".genomedca', 0.1, {:d}); exit".format(cores)]))
+
+            t = subprocess.check_output([matlab, '--no-gui', '--eval', "pkg load bioinfo; path(path, 'PLMDCAPATH'); path(path, 'PLMDCAPATH/functions'); path(path, 'PLMDCAPATH/3rd_party_code/minFunc/'); plmDCA_asymmetric ( '".replace('PLMDCAPATH', plmdca) + infilestem + ".seq', '" + infilestem + ".genomedca', 0.1, {:d}); exit".format(cores)])
+except Exception as e:
+    print(e)
+    sys.stderr.write('{:s} inputfile1.seq [inputfile2.seq ...]\n'.format(sys.argv[0])) 
+    sys.stderr.write('\nThis script will run genomeDCA on all the input files provided in the command line\nREMEMBER: set the path to MATLAB executable and genomeDCA code in the header of the script\n')

--- a/02inference/README.md
+++ b/02inference/README.md
@@ -20,4 +20,9 @@ This step will infer evolutionary couplings between loci in pseudo-alignments ge
 
     Note: `./00rungenomeDCA` can take more than one alignment input in the command line. In such a case, the inference will be run sequentially.
 
-3. Wait until inference finishes. Single run takes ~10 minutes, out of which ~75% is spent in parallelized loop. When using 20 cores the run time can be reduced to ~3 minutes. Each sample can be run independently. 
+3. Wait until inference finishes. Single run takes ~10 minutes, out of which ~75% is spent in parallelized loop. When using 20 cores the run time can be reduced to ~3 minutes. Each sample can be run independently.
+
+## Using GNU octave instead of MATLAB
+
+1. Move genomeDCA/plmDCA_asymmetric_octave.m to genomeDCA/plmDCA_asymmetric.m
+2. Use ./00rungenomeDCAoctave.py instead of ./00rungenomeDCA.py

--- a/02inference/genomeDCA/plmDCA_asymmetric_octave.m
+++ b/02inference/genomeDCA/plmDCA_asymmetric_octave.m
@@ -1,0 +1,294 @@
+% Copyright 2016 - by Marcin J. Skwark <marcin@skwark.pl>
+% Copyright 2014 - by Magnus Ekeberg <magnus.ekeberg@gmail.com>
+% All rights reserved
+% 
+% Permission is granted for anyone to copy, use, or modify this
+% software for any uncommercial purposes, provided this copyright 
+% notice is retained, and note is made of any changes that have 
+% been made. This software is distributed without any warranty, 
+% express or implied. In no event shall the author or contributors be 
+% liable for any damage arising out of the use of this software.
+% 
+% The publication of research using this software, modified or not, must include 
+% appropriate citations to:
+% 
+%   M.J. Skwark, N.J. Croucher,..., E. Aurell, J. Corander
+%   Whole-genome linkage analysis reveals co-evolutionary mechanisms of 
+%   antibiotic resistance in the Pneumococcus.
+%
+% This software has been based on method described in:
+% 	M. Ekeberg, C. Lövkvist, Y. Lan, M. Weigt, E. Aurell, Improved contact
+% 	prediction in proteins: Using pseudolikelihoods to infer Potts models, Phys. Rev. E 87, 012707 (2013)
+%
+%	M. Ekeberg, T. Hartonen, E. Aurell, Fast pseudolikelihood
+%	maximization for direct-coupling analysis of protein structure
+%	from many homologous amino-acid sequences, J. Comput. Phys. 276, 341-356 (2014)
+% 
+% This software includes modifications described in:
+%
+%	C. Feinauer, MJ. Skwark, A. Pagnani, E.Aurell, Improving contact 
+%	prediction along three dimensions, PLoS Comput Biol 10(10): e1003847. 
+%	doi: 10.1371/journal.pcbi.1003847
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
+
+
+function plmDCA_asymmetric(fastafile,outputfile,reweighting_threshold,nr_of_cores)
+%If should-be numericals are passed as strings, convert them.
+    if (isstr(reweighting_threshold))
+        reweighting_threshold = str2num(reweighting_threshold);
+    end
+    if (isstr(nr_of_cores))
+        nr_of_cores = str2num(nr_of_cores);
+    end
+
+%Minimization options
+    options.method='lbfgs'; %Minimization scheme. Default: 'lbfgs', 'cg' for conjugate gradient (use 'cg' if out of RAM).
+    options.Display='off';
+    options.progTol=1e-9; %Threshold for when to terminate the descent. Default: 1e-9. 
+%A note on progTol: In our experiments on PFAM-families, a progTol of 1e-3 gave identical true-positive rates to 1e-9 (default), but with moderately shorter running time. Differences in the scores between progTol 1e-3 and 1e-9 showed up in the 3rd-4th decimal or so (which tends to matter little when ranking them). We here set 1e-7 to be on the safe side, but this can be raised to gain speed. If, however, one wishes to use the scores for some different application, or extract and use the parameters {h,J} directly, we recommend the default progTol 1e-9.
+
+    addpath(genpath(pwd))
+    
+%Read inputfile (removing inserts), remove duplicate sequences, and calculate weights and B_eff.
+    [N,B_with_id_seq,q,Y]=return_alignment(fastafile);
+    Y=unique(Y,'rows');
+    [B,N]=size(Y);
+    weights = ones(B,1);
+    if reweighting_threshold>0.0
+        fprintf('Starting to calculate weights \n...');
+        tic
+        %Reweighting in MATLAB:            
+        %weights = (1./(1+sum(squareform(pdist(Y,'hamm')<=reweighting_threshold))))';       
+	     
+        %Reweighting in C:
+        Y=int32(Y);
+        m=calc_inverse_weights(Y-1,reweighting_threshold);
+        weights=1./m;
+
+        fprintf('Finished calculating weights \n');
+        toc
+    end
+    B_eff=sum(weights);
+    fprintf('### N = %d B_with_id_seq = %d B = %d B_eff = %.2f q = %d\n',N,B_with_id_seq,B,B_eff,q);
+   	
+%Prepare inputs to optimizer.
+    %Automatic specification of regularization strength based on B_eff. B_eff>500 means the standard regularization 0.01 is used, while B_eff<=500 means a higher regularization is chosen.
+    if B_eff>500
+        lambda_J=0.1;
+    else
+        lambda_J=1-(1-0.1)*B_eff/500;
+    end 
+    lambda_h=lambda_J;
+    scaled_lambda_h=lambda_h*B_eff;   
+    scaled_lambda_J=lambda_J*B_eff/2; %Divide by 2 to keep the size of the coupling regularizaion equivalent to symmetric variant of plmDCA.
+
+    Y=int32(Y);q=int32(q);
+    w=zeros(q+q^2*(N-1),N); %Matrix in which to store parameter estimates (column r will contain estimates from g_r).
+%Run optimizer.
+    if nr_of_cores>1
+        %matlabpool('open',nr_of_cores)   
+        tic
+        parfor r=1:N
+            disp(strcat('Minimizing g_r for node r=',int2str(r)))       
+            wr=min_g_r(Y,weights,N,q,scaled_lambda_h,scaled_lambda_J,r,options);
+            w(:,r)=wr;
+        end
+        toc
+        %matlabpool('close')
+    else
+        tic
+        for r=1:N
+            disp(strcat('Minimizing g_r for node r=',int2str(r)))       
+            wr=min_g_r(Y,weights,N,q,scaled_lambda_h,scaled_lambda_J,r,options);
+            w(:,r)=wr;
+        end
+        toc
+    end
+
+%Extract the coupling estimates from w.
+    JJ=reshape(w(q+1:end,:),q,q,N-1,N);
+    Jtemp1=zeros(q,q,N*(N-1)/2);
+    Jtemp2=zeros(q,q,N*(N-1)/2);  
+    l=1;
+    for i=1:(N-1)
+         for j=(i+1):N
+            Jtemp1(:,:,l)=JJ(:,:,j-1,i); %J_ij as estimated from from g_i.
+	    Jtemp2(:,:,l)=JJ(:,:,i,j)'; %J_ij as estimated from from g_j.
+            l=l+1;
+        end
+    end
+
+    disp('Finished extracting coupling estimates')
+
+%A note on gauges: 
+%The parameter estimates coming from g_r satisfy the gauge
+%	lambda_J*sum_s Jtemp_ri(s,k) = 0
+%	lambda_J*sum_k Jtemp_ri(s,k) = lambda_h*htemp_r(s)	
+%	sum_s htemp_r(s) = 0.
+%Only the couplings are used in what follows.
+    
+    
+%Shift the coupling estimates into the Ising gauge.
+    J1=zeros(q,q,N*(N-1)/2);
+    J2=zeros(q,q,N*(N-1)/2);
+    for l=1:(N*(N-1)/2)
+        J1(:,:,l)=Jtemp1(:,:,l)-repmat(mean(Jtemp1(:,:,l)),q,1)-repmat(mean(Jtemp1(:,:,l),2),1,q)+mean(mean(Jtemp1(:,:,l)));
+	J2(:,:,l)=Jtemp2(:,:,l)-repmat(mean(Jtemp2(:,:,l)),q,1)-repmat(mean(Jtemp2(:,:,l),2),1,q)+mean(mean(Jtemp2(:,:,l)));
+    end
+%Take J_ij as the average of the estimates from g_i and g_j.
+    J=0.5*(J1+J2);
+    disp('Finished gauge shifting')
+
+
+%Calculate frob. norms FN_ij.
+    NORMS=zeros(N,N); 
+    l=1;
+    for i=1:(N-1)
+        for j=(i+1):N
+            NORMS(i,j)=norm(J(2:end,2:end,l),'fro');
+            NORMS(j,i)=NORMS(i,j);
+            l=l+1;
+        end
+    end               
+    disp('Finished Frobenius norm')
+       
+    
+%Calculate scores CN_ij=FN_ij-(FN_i-)(FN_-j)/(FN_--), where '-'
+%denotes average.
+%    norm_means=mean(NORMS)*N/(N-1);
+%    norm_means_all=mean(mean(NORMS))*N/(N-1);
+%    CORRNORMS=NORMS-norm_means'*norm_means/norm_means_all;
+    CORRNORMS=NORMS;
+    output=[];
+    for i=1:(N-1)
+        for j=(i+1):N
+            output=[output;[i,j,CORRNORMS(i,j)]];
+        end
+    end
+    disp('Writing results')
+    dlmwrite(outputfile,output,'precision',5)
+end
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+function [wr]=min_g_r(Y,weights,N,q,scaled_lambda_h,scaled_lambda_J,r,options)
+%Creates function object for (regularized) g_r and minimizes it using minFunc.
+    r=int32(r);
+    funObj=@(wr)g_r(wr,Y,weights,N,q,scaled_lambda_h,scaled_lambda_J,r);        
+    wr0=zeros(q+q^2*(N-1),1);
+    wr=minFunc(funObj,wr0,options);    
+end
+
+function [fval,grad] = g_r(wr,Y,weights,N,q,lambdah,lambdaJ,r)
+%Evaluates (regularized) g_r using the mex-file.
+	h_r=reshape(wr(1:q),1,q);
+	J_r=reshape(wr(q+1:end),q,q,N-1);
+
+	r=int32(r);
+	[fval,grad1,grad2] = g_rC(Y-1,weights,h_r,J_r,[lambdah;lambdaJ],r);
+	grad = [grad1(:);grad2(:)];
+end
+
+function [N,B,q,Y] = return_alignment(inputfile)
+%Reads alignment from inputfile, removes inserts and converts into numbers.
+    align_full = fastaread(inputfile);
+    B = length(align_full);
+    seq = cell2struct(align_full(1), 'dummy').dummy;
+    ind = seq.Sequence ~= '.' & seq.Sequence == upper( seq.Sequence );
+    N = sum(ind);
+    Y = zeros(B,N);
+
+    for i=1:B
+        counter = 0;
+        for j=1:length(ind)
+            if( ind(j) )
+                counter = counter + 1;
+		seq = cell2struct(align_full(i), 'dummy').dummy;
+                Y(i,counter)=letter2number( seq.Sequence(j) );
+            end
+        end
+    end
+    q=max(max(Y));
+end
+
+function x=letter2number(a)
+    switch(a)
+        % full AA alphabet
+        case '-'
+             x=1;
+        case 'A'    
+            x=4;    
+        case 'C'    
+            x=5;
+        case 'D'
+            x=6;
+        case 'E'  
+            x=2;
+        case 'F'
+            x=3;
+        case 'G'  
+            x=7;
+        case 'H'
+            x=8;
+        case 'I'  
+            x=9;
+        case 'K'
+            x=10;
+        case 'L'  
+            x=11;
+        case 'M'
+            x=12;
+        case 'N'  
+            x=13;
+        case 'P'
+            x=14;
+        case 'Q'
+            x=15;
+        case 'R'
+            x=16;
+        case 'S'  
+            x=17;
+        case 'T'
+            x=18;
+        case 'V'
+            x=19;
+        case 'W'
+            x=20;
+        case 'Y'
+            x=21;
+        otherwise
+            x=1;
+    end
+end
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Hi,

I have added two new files to help users who want to use Octave instead of Matlab; I had only 1 license on our cluster so that I couldn't run all the sampling in parallel.
I also made the python scripts compatible with python 3

Thanks for the very useful package.
Marco